### PR TITLE
Get token count for FactCheck().check_response

### DIFF
--- a/factcheck/__init__.py
+++ b/factcheck/__init__.py
@@ -142,6 +142,22 @@ class FactCheck:
         api_data_dict = self._post_process(api_data_dict, claim_verify_dict)
         api_data_dict["step_info"] = api_data_dict["step_info"]
 
+        # Sum up prompt and completion tokens
+        total_prompt_tokens = 0
+        total_completion_tokens = 0
+        for submodule in [
+            self.decomposer,
+            self.checkworthy,
+            self.query_generator,
+            self.claimverify,
+        ]:
+            total_prompt_tokens += submodule.llm_client.prompt_tokens
+            total_completion_tokens += submodule.llm_client.completion_tokens
+        api_data_dict["token_count"]["total_prompt_tokens"] = total_prompt_tokens
+        api_data_dict["token_count"][
+            "total_completion_tokens"
+        ] = total_completion_tokens
+
         return api_data_dict
 
     def _post_process(self, api_data_dict, claim_verify_dict: dict):

--- a/factcheck/utils/llmclient/gpt_client.py
+++ b/factcheck/utils/llmclient/gpt_client.py
@@ -1,4 +1,3 @@
-import time
 from openai import OpenAI
 from .base import BaseClient
 
@@ -13,6 +12,8 @@ class GPTClient(BaseClient):
     ):
         super().__init__(model, api_config, max_requests_per_minute, request_window)
         self.client = OpenAI(api_key=self.api_config["OPENAI_API_KEY"])
+        self.prompt_tokens = 0
+        self.completion_tokens = 0
 
     def _call(self, messages: str, **kwargs):
         seed = kwargs.get("seed", 42)  # default seed is 42
@@ -25,6 +26,8 @@ class GPTClient(BaseClient):
             messages=messages,
         )
         r = response.choices[0].message.content
+        self.prompt_tokens += response.usage.prompt_tokens
+        self.completion_tokens += response.usage.completion_tokens
         return r
 
     def get_request_length(self, messages):


### PR DESCRIPTION
Usage:
```
import sys
sys.path.append("/Users/evan/dev/OpenFactVerification")
from dotenv import load_dotenv
from factcheck import FactCheck

load_dotenv(dotenv_path="/Users/evan/dev/OpenFactVerification/.env")
results = FactCheck().check_response("The sky is green")
print(results["token_count"])
```
Gives
```
{'num_raw_tokens': 4, 'num_checkworthy_tokens': 5, 'total_prompt_tokens': 1748, 'total_completion_tokens': 231}
```